### PR TITLE
respecting MiniSessions.config.autowrite

### DIFF
--- a/lua/telescope/_extensions/sessions_picker/main.lua
+++ b/lua/telescope/_extensions/sessions_picker/main.lua
@@ -4,6 +4,7 @@ P = function(v)
 end
 
 local has_telescope, telescope = pcall(require, 'telescope')
+local has_minisessions, mini = pcall(require, 'mini.sessions')
 
 if not has_telescope then
   error('This plugins requires nvim-telescope/telescope.nvim')
@@ -23,7 +24,11 @@ local load_session = function(prompt_bufnr)
   local dir = actions_state.get_selected_entry(prompt_bufnr).value
   actions.close(prompt_bufnr, true)
   local current_sdir = vim.api.nvim_eval('v:this_session')
-  if current_sdir or current_sdir ~= '' then --save current session if exist
+  if has_minisessions then
+    if MiniSessions.config.autowrite then
+      vim.fn.execute("mksession! "..current_sdir)
+    end
+  else if current_sdir or current_sdir ~= '' then --save current session if exist
     vim.fn.execute("mksession! "..current_sdir)
   end
 	--  vim.fn.execute(":LspStop", "silent")

--- a/lua/telescope/_extensions/sessions_picker/main.lua
+++ b/lua/telescope/_extensions/sessions_picker/main.lua
@@ -25,10 +25,10 @@ local load_session = function(prompt_bufnr)
   actions.close(prompt_bufnr, true)
   local current_sdir = vim.api.nvim_eval('v:this_session')
   if has_minisessions then
-    if MiniSessions.config.autowrite then
+    if mini.config.autowrite then
       vim.fn.execute("mksession! "..current_sdir)
     end
-  else if current_sdir or current_sdir ~= '' then --save current session if exist
+  elseif current_sdir or current_sdir ~= '' then --save current session if exist
     vim.fn.execute("mksession! "..current_sdir)
   end
 	--  vim.fn.execute(":LspStop", "silent")


### PR DESCRIPTION
Opening a session from the telescope sessions_picker writes a 'Session.vim' in the directory from which nvim is launched. This is regardless of `MiniSessions.config.autowrite` value, which I have set to false. 

This is a small fix to prevent the call to `mksession` if the `autowrite = false`.

Feel free to reject this if you do not think this is suitable for general use – I am not a programmer, and do not know lua at all. But the change should be enough for my needs, so offering it if you want. 

Thanks for the plugin - it was exactly what I was looking for, and I changed to mini.sessions specifically to integrate with telescope when I found this plugin. 