### PR TITLE
fix: prevent creation of Session.vim if mini.sessions is used

### DIFF
--- a/lua/telescope/_extensions/sessions_picker/main.lua
+++ b/lua/telescope/_extensions/sessions_picker/main.lua
@@ -24,12 +24,14 @@ local load_session = function(prompt_bufnr)
   local dir = actions_state.get_selected_entry(prompt_bufnr).value
   actions.close(prompt_bufnr, true)
   local current_sdir = vim.api.nvim_eval('v:this_session')
-  if has_minisessions then
-    if mini.config.autowrite then
-      vim.fn.execute("mksession! "..current_sdir)
+  if current_sdir and current_sdir ~= "" then --save current session if exist
+    if has_minisessions then
+      if mini.config.autowrite then
+        vim.fn.execute("mksession! " .. current_sdir)
+      end
+    else
+      vim.fn.execute("mksession! " .. current_sdir)
     end
-  elseif current_sdir or current_sdir ~= '' then --save current session if exist
-    vim.fn.execute("mksession! "..current_sdir)
   end
 	--  vim.fn.execute(":LspStop", "silent")
 	--  vim.fn.execute(":bufdo bwipeout!", "silent")


### PR DESCRIPTION
This patch unifies the behavior between the use of mini.sessions and plain session management. No Session.vim is written, if no previous session exists.

Closes #4 